### PR TITLE
recpt1 のHTTPモードでクライアントが接続時 SIGSEGV で落ちる問題修正

### DIFF
--- a/recpt1/recpt1.c
+++ b/recpt1/recpt1.c
@@ -897,7 +897,7 @@ main(int argc, char **argv)
                 sid_list = sidflg;
             fprintf(stderr,"channel is %s\n",channel);
 
-            if(!strcmp(sid_list,"all")){
+            if(sid_list == NULL || !strcmp(sid_list,"all")){
                 use_splitter = FALSE;
                 splitter = NULL;
             }else{


### PR DESCRIPTION
バグ修正 #2 

症状を直接こちらのプルリク本文に書いていましたが、Issue として登録しなおしたためこちらも編集しました。

## 変更内容
簡単に周辺のコードを調べて、sid_list 変数が NULL であるために問題が発生していることを突き止めたので sid_list が NULL の場合は tssplitter を使用しないように変更。

HTTP モード使用時はもともと --sid オプションの有無に関わらず tssplitter を使用することを前提としたコードが組まれていました。従って、HTTP モードでは URL にて sid が指定されない場合 "hd" 等で強制しても構わないかと思いましたが --sid オプションが HTTP モードでは無意味になってしまうので、--sid オプションが指定されていない場合には tssplitter を使わず全てのストリームを送信するようにしました。HTTP モードでクライアントからの接続時に sid が指定されなければ --sid オプションで指定した sid が有効になります（これは、以前の動作と変わりません）。