### PR TITLE
Fix #3 musl 環境下でのビルドエラーの修正

### DIFF
--- a/recpt1/decoder.h
+++ b/recpt1/decoder.h
@@ -10,12 +10,12 @@
 #include <arib25/arib_std_b25.h>
 #include <arib25/b_cas_card.h>
 
-typedef struct decoder {
+typedef struct {
     ARIB_STD_B25 *b25;
     B_CAS_CARD *bcas;
 } decoder;
 
-typedef struct decoder_options {
+typedef struct {
     int round;
     int strip;
     int emm;
@@ -28,11 +28,11 @@ typedef struct {
     int32_t  size;
 } ARIB_STD_B25_BUFFER;
 
-typedef struct decoder {
+typedef struct {
     void *dummy;
 } decoder;
 
-typedef struct decoder_options {
+typedef struct {
     int round;
     int strip;
     int emm;

--- a/recpt1/recpt1.h
+++ b/recpt1/recpt1.h
@@ -15,12 +15,12 @@
 #define ISDB_T_NODE_LIMIT 24        // 32:ARIB limit 24:program maximum
 #define ISDB_T_SLOT_LIMIT 8
 
-typedef struct _BUFSZ {
+typedef struct {
     int size;
     u_char buffer[MAX_READ_SIZE];
 } BUFSZ;
 
-typedef struct _QUEUE_T {
+typedef struct {
     unsigned int in;        // 次に入れるインデックス
     unsigned int out;        // 次に出すインデックス
     unsigned int size;        // キューのサイズ
@@ -32,7 +32,7 @@ typedef struct _QUEUE_T {
     BUFSZ *buffer[1];    // バッファポインタ
 } QUEUE_T;
 
-typedef struct _ISDB_T_FREQ_CONV_TABLE {
+typedef struct {
     int set_freq;    // 実際にioctl()を行う値
     int type;        // チャンネルタイプ
     int add_freq;    // 追加する周波数(BS/CSの場合はスロット番号)

--- a/recpt1/recpt1core.h
+++ b/recpt1/recpt1core.h
@@ -45,17 +45,17 @@
 /* type definitions */
 typedef int boolean;
 
-typedef struct sock_data {
+typedef struct {
     int sfd;    /* socket fd */
     struct sockaddr_in addr;
 } sock_data;
 
-typedef struct msgbuf {
+typedef struct {
     long    mtype;
     char    mtext[MSGSZ];
 } message_buf;
 
-typedef struct thread_data {
+typedef struct {
     int tfd;    /* tuner fd */ //xxx variable
 
     int wfd;    /* output file fd */ //invariable

--- a/recpt1/tssplitter_lite.c
+++ b/recpt1/tssplitter_lite.c
@@ -24,6 +24,7 @@
 
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include "decoder.h"
 #include "recpt1.h"
 #include "tssplitter_lite.h"


### PR DESCRIPTION
インクルード漏れの修正と、どこからも参照されていない構造体名の削除のみのため副作用はないと思います。構造体定義名の衝突は実際に問題となっているのは `struct msgbuf {}` のみですが、他の構造体も型名で参照されていて構造体名での参照はないようだったため削除しました。

ヘッダーファイルがインストールされることはないようなので、構造体名が消えることによる他の利用者への影響もほぼ無いと思います。