### PR TITLE
Fix #5 BSジャパンの周波数変更への対応

### DIFF
--- a/README
+++ b/README
@@ -21,8 +21,8 @@ make
 13-62: Terrestrial Channels
 BS01_0: BS朝日
 BS01_1: BS-TBS
+BS01_2: BSジャパン
 BS03_0: WOWOWプライム
-BS03_1: BSジャパン
 BS05_0: WOWOWライブ
 BS05_1: WOWOWシネマ
 BS07_0: スターチャンネル2/3

--- a/driver/pt1_pci.c
+++ b/driver/pt1_pci.c
@@ -8,6 +8,7 @@
 #include <linux/pci.h>
 #include <linux/init.h>
 #include <linux/interrupt.h>
+#include <linux/vmalloc.h>
 #include <linux/version.h>
 #include <linux/mutex.h>
 

--- a/recpt1/pt1_dev.h
+++ b/recpt1/pt1_dev.h
@@ -41,7 +41,7 @@ ISDB_T_FREQ_CONV_TABLE    isdb_t_conv_table[] = {
     {   0, CHTYPE_SATELLITE, 0, "151"},  /* 151ch：BS朝日 */
     {   0, CHTYPE_SATELLITE, 1, "161"},  /* 161ch：BS-TBS */
     {   1, CHTYPE_SATELLITE, 0, "191"},  /* 191ch：WOWOW prime */
-    {   1, CHTYPE_SATELLITE, 1, "171"},  /* 171ch：BSジャパン */
+    {   0, CHTYPE_SATELLITE, 2, "171"},  /* 171ch：BSジャパン */
     {   2, CHTYPE_SATELLITE, 0, "192"},  /* 192ch：WOWOWライブ */
     {   2, CHTYPE_SATELLITE, 1, "193"},  /* 193ch：WOWOWシネマ */
     {   3, CHTYPE_SATELLITE, 0, "201"},  /* 201ch：スター・チャンネル2 */

--- a/recpt1/recpt1core.c
+++ b/recpt1/recpt1core.c
@@ -197,8 +197,8 @@ show_channels(void)
 
     fprintf(stderr, "BS01_0: BS朝日\n");
     fprintf(stderr, "BS01_1: BS-TBS\n");
+    fprintf(stderr, "BS01_2: BSジャパン\n");
     fprintf(stderr, "BS03_0: WOWOWプライム\n");
-    fprintf(stderr, "BS03_1: BSジャパン\n");
     fprintf(stderr, "BS05_0: WOWOWライブ\n");
     fprintf(stderr, "BS05_1: WOWOWシネマ\n");
     fprintf(stderr, "BS07_0: スターチャンネル2/3\n");


### PR DESCRIPTION
### 概要

表題の通り、BSジャパンの周波数変更があったため周波数変更への対応パッチです。
@simplelife0530 氏が Issue #5 で報告している問題を解決します。

また、上記 Issue とは関係ありませんが pt1 のドライバが
ビルド出来ないようだったのでインクルード漏れを修正しました。

### フォローアップ
簡単なパッチなので問題はないかと思います。
動作も確認済みですが、この問題に関連してドキュメント等に変更漏れがあるかもしれません。
もし気付いたら教えていただけると幸いです。