### PR TITLE
PX4デバイス名の追加

### DIFF
--- a/recpt1/pt1_dev.h
+++ b/recpt1/pt1_dev.h
@@ -14,7 +14,11 @@ char *bsdev[NUM_BSDEV] = {
     "/dev/pt3video1",
     "/dev/pt3video0",
     "/dev/pt3video5",
-    "/dev/pt3video4"
+    "/dev/pt3video4",
+    "/dev/px4video0",
+    "/dev/px4video1",
+    "/dev/px4video4",
+    "/dev/px4video5"
 };
 char *isdb_t_dev[NUM_ISDB_T_DEV] = {
     "/dev/pt1video2",
@@ -28,7 +32,11 @@ char *isdb_t_dev[NUM_ISDB_T_DEV] = {
     "/dev/pt3video2",
     "/dev/pt3video3",
     "/dev/pt3video6",
-    "/dev/pt3video7"
+    "/dev/pt3video7",
+    "/dev/px4video2",
+    "/dev/px4video3",
+    "/dev/px4video6",
+    "/dev/px4video7"
 };
 
 // 変換テーブル(ISDB-T用)

--- a/recpt1/recpt1.h
+++ b/recpt1/recpt1.h
@@ -2,8 +2,8 @@
 #ifndef _RECPT1_H_
 #define _RECPT1_H_
 
-#define NUM_BSDEV       12
-#define NUM_ISDB_T_DEV  12
+#define NUM_BSDEV       16
+#define NUM_ISDB_T_DEV  16
 #define CHTYPE_SATELLITE    0        /* satellite digital */
 #define CHTYPE_GROUND       1        /* terrestrial digital */
 #define MAX_QUEUE           8192


### PR DESCRIPTION
PLEX製USBチューナーのデバイス名を追加して、デバイス名指定なしでの録画ができるようにしました。