### PR TITLE
Mutexのロック解除タイミングを修正

### DIFF
--- a/driver/pt1_pci.c
+++ b/driver/pt1_pci.c
@@ -404,12 +404,13 @@ static int pt1_release(struct inode *inode, struct file *file)
 		channel->req_dma = FALSE ;
 		wake_up(&channel->ptr->dma_wait_q);
 	}
-	mutex_unlock(&channel->ptr->lock);
 
 	/* send tuner to sleep */
 	set_sleepmode(channel->ptr->regs, &channel->lock,
 				  channel->address, channel->type, TYPE_SLEEP);
 	schedule_timeout_interruptible(msecs_to_jiffies(100));
+
+	mutex_unlock(&channel->ptr->lock);
 
 	return 0;
 }


### PR DESCRIPTION
[PT2ドライババグの注意喚起](https://gist.github.com/akimasa/a2fc1fc098dee1e27ab88fab3ff27d23) を参考にした修正です。

こちらのリポジトリではドライバは管理されていないのかもしれないのですが、
有名なリポジトリのため主要な修正は入っている方が好ましいと思いPRさせていただきました。
