### PR TITLE
Kernel 5.18以降をサポート

### DIFF
--- a/driver/pt1_pci.c
+++ b/driver/pt1_pci.c
@@ -32,6 +32,7 @@ typedef struct pm_message {
 } pm_message_t;
 #endif
 #endif
+
 #include <linux/kthread.h>
 #include <linux/dma-mapping.h>
 
@@ -56,6 +57,28 @@ typedef struct pm_message {
 
 #if LINUX_VERSION_CODE > KERNEL_VERSION(4,2,0)
 #include <linux/vmalloc.h>
+#endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
+static inline void *pci_alloc_consistent(struct pci_dev *hwdev, size_t size, dma_addr_t *dma_handle)
+{
+	return dma_alloc_coherent(&hwdev->dev, size, dma_handle, GFP_ATOMIC);
+}
+
+static inline void pci_free_consistent(struct pci_dev *hwdev, size_t size, void *vaddr, dma_addr_t dma_handle)
+{
+	dma_free_coherent(&hwdev->dev, size, vaddr, dma_handle);
+}
+
+static inline int pci_set_dma_mask(struct pci_dev *hwdev, u64 mask)
+{
+	if (!dma_supported(&hwdev->dev, mask))
+		return -EIO;
+
+	hwdev->dma_mask = mask;
+
+	return 0;
+}
 #endif
 
 /* These identify the driver base version and may not be removed. */

--- a/driver/pt1_pci.c
+++ b/driver/pt1_pci.c
@@ -62,7 +62,7 @@ typedef struct pm_message {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
 static inline void *pci_alloc_consistent(struct pci_dev *hwdev, size_t size, dma_addr_t *dma_handle)
 {
-	return dma_alloc_coherent(&hwdev->dev, size, dma_handle, GFP_ATOMIC);
+	return dma_alloc_coherent(&hwdev->dev, size, dma_handle, GFP_KERNEL);
 }
 
 static inline void pci_free_consistent(struct pci_dev *hwdev, size_t size, void *vaddr, dma_addr_t dma_handle)
@@ -72,12 +72,7 @@ static inline void pci_free_consistent(struct pci_dev *hwdev, size_t size, void 
 
 static inline int pci_set_dma_mask(struct pci_dev *hwdev, u64 mask)
 {
-	if (!dma_supported(&hwdev->dev, mask))
-		return -EIO;
-
-	hwdev->dma_mask = mask;
-
-	return 0;
+	return dma_set_mask(&hwdev->dev, mask);
 }
 #endif
 


### PR DESCRIPTION
こちらも #16 と同様の意図でのPRです。

参考:
- https://github.com/m-tsudo/pt3/commit/c10619da580e3a801b205df2ba4a95a850a38786
- https://community.asterisk.org/t/can-not-compile-dahdi-3-2-on-fedora-36/94064/3