### PR TITLE
BSトゥエルビとBS松竹東急が録画できない現象が発生したので修正

### DIFF
--- a/recpt1/pt1_dev.h
+++ b/recpt1/pt1_dev.h
@@ -247,7 +247,7 @@ ISDB_T_FREQ_CONV_TABLE    isdb_t_conv_table[] = {
     {   2, CHTYPE_SATELLITE, 0, "192"},  /* 192ch：WOWOWライブ */
     {   2, CHTYPE_SATELLITE, 1, "193"},  /* 193ch：WOWOWシネマ */
     {   4, CHTYPE_SATELLITE, 0, "211"},  /* 211ch：BS11イレブン */
-    {   4, CHTYPE_SATELLITE, 2, "222"},  /* 222ch：BS12トゥエルビ */
+    {   4, CHTYPE_SATELLITE, 1, "222"},  /* 222ch：BS12トゥエルビ */
     {   6, CHTYPE_SATELLITE, 2, "231"},  /* 231ch：放送大学ex */
     {   6, CHTYPE_SATELLITE, 2, "232"},  /* 232ch：放送大学on */
     {   6, CHTYPE_SATELLITE, 2, "531"},  /* 531ch：放送大学ラジオ */

--- a/recpt1/recpt1core.c
+++ b/recpt1/recpt1core.c
@@ -204,7 +204,7 @@ show_channels(void)
     fprintf(stderr, "BS05_0: WOWOWライブ\n");
     fprintf(stderr, "BS05_1: WOWOWシネマ\n");
     fprintf(stderr, "BS09_0: BS11イレブン\n");
-    fprintf(stderr, "BS09_2: BS12トゥエルビ\n");
+    fprintf(stderr, "BS09_1: BS12トゥエルビ\n");
     fprintf(stderr, "BS13_0: BS日テレ\n");
     fprintf(stderr, "BS13_1: BSフジ\n");
     fprintf(stderr, "BS13_2: 放送大学\n");
@@ -220,7 +220,7 @@ show_channels(void)
     fprintf(stderr, "BS21_2: グリーンチャンネル\n");
     fprintf(stderr, "BS23_0: ディズニーch\n");
     fprintf(stderr, "BS23_1: BSよしもと\n");
-    fprintf(stderr, "BS23_3: BS松竹東急\n");
+    fprintf(stderr, "BS23_2: BS松竹東急\n");
     fprintf(stderr, "C13-C63: CATV Channels\n");
     fprintf(stderr, "CS2-CS24: CS Channels\n");
 }


### PR DESCRIPTION
BS12トゥエルビのチャンネル番号指定でのスロット変更に対応
BS12トゥエルビのチャンネル文字列でのスロット変更に対応
BS松竹東急のチャンネル文字列でのスロット番号を修正